### PR TITLE
Added addSwitchActuatorState and fixed a bug

### DIFF
--- a/Request/SetActuatorStatesRequest.php
+++ b/Request/SetActuatorStatesRequest.php
@@ -50,11 +50,24 @@ class SetActuatorStatesRequest extends BaseRequest
 	public function addRoomTemperatureActuatorState($logicalDeviceId, $pointTemperature, $mode)
 	{
 		$this->actuatorStates[] = array(
-			'xsi:type' => 'RoomTemperatureActuatorState',
+			'xmlns:xsi:type' => 'RoomTemperatureActuatorState',
 			'LID' => $logicalDeviceId,
 			'PtTmp' => $pointTemperature,
 			'OpnMd' => $mode,
 			'WRAc' => false
+		);
+	}
+	
+	/**
+	 * @param string $logicalDeviceId the logical device id
+	 * @param bool $value the state to set
+	 */
+	public function addSwitchActuatorState($logicalDeviceId, $value)
+	{
+		$this->actuatorStates[] = array(
+			'xmlns:xsi:type' => 'SwitchActuatorState',
+			'LID' => $logicalDeviceId,
+			'IsOn' => $value
 		);
 	}
 }


### PR DESCRIPTION
Added addSwitchActuatorState
Fixed xml-namespace being removed by SimpleXML by adding a "xmlns" ('xsi:type' was changed to 'type' in SetActuatorStatesRequest.php)
